### PR TITLE
Fix hardcoded path breaking with npm 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var inherits = require('util').inherits;
 var Service, Characteristic, VolumeCharacteristic;
 var sonosDevices = new Map();
 var sonosAccessories = [];
-var Listener = require('../homebridge-sonos/node_modules/sonos/lib/events/listener');
+var Listener = require('sonos/lib/events/listener');
 
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;


### PR DESCRIPTION
Sub-dependencies are now all stored in the one master node_modules directory: https://docs.npmjs.com/how-npm-works/npm3. This removes the hardcoded path in a require() that shouldn't really have been there anyway, and allows node to resolve it.

Fixes #29.
