### PR TITLE
use current version of sonos

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ SonosAccessory.prototype.search = function() {
                                         if (coordinator.ip == data.ip) {
                                                 this.log("Found a playable coordinator device at %s in zone '%s' for accessory '%s' in accessory room '%s'", data.ip, data.CurrentZoneName, this.name, this.room);
                                                 this.device = device;
-                                                search.socket.close(); // we don't need to continue searching.
+                                                search.destroy(); // we don't need to continue searching.
                                         }
                                 }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
-    "sonos": "^0.8.0",
+    "sonos": "^0.12.1",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
to avoid bug in earlier version of `request` package that is used by `sonos@0.8.0` -- the bug: if network connectivity was lost, then the earlier version of `request` would generate an uncaught error resulting in `homebridge` termination!

the only API impact in the use of `sonos@0.12.1` is to use `Search.prototype.destroy` instead of closing the socket directly in `index.js`