### PR TITLE
Switch will mute/unmute instead of play/stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Example config.json:
           "accessory": "Sonos",
           "name": "Bedroom Speakers",
           "room": "Bedroom",
-	  "mute": true
+          "mute": true
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Example config.json:
         {
           "accessory": "Sonos",
           "name": "Bedroom Speakers",
-          "room": "Bedroom"
+          "room": "Bedroom",
+	  "mute": true
         }
       ]
     }
@@ -16,6 +17,8 @@ Example config.json:
 The `room` parameter must match the room name in Sonos exactly.
 
 Note that the name "Speakers" is used in the name for this example instead of something more intuitive like "Sonos" or "Music" or "Radio", as Siri has many stronger associations for those words. For instance, including "Sonos" in the name will likely cause Siri to just launch the Sonos app. And including "Music" in the name will cause Siri to launch the built-in Music app.
+
+The "mute" parameter is optional.  Setting it to `true` will mute/unmute the speaker instead of a stop/play.
 
 # Alternative
 

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ function SonosAccessory(log, config) {
   this.config = config;
   this.name = config["name"];
   this.room = config["room"];
+  this.mute = config["mute"];
 
   if (!this.room) throw new Error("You must provide a config value for 'room'.");
 
@@ -223,18 +224,32 @@ SonosAccessory.prototype.getOn = function(callback) {
     return;
   }
 
-  this.device.getMuted(function(err, state) {
+  if (!this.mute) {
+    this.device.getCurrentState(function(err, state) {
+      if (err) {
+        callback(err);
+      }
+      else {
+        this.log.warn("Current state for Sonos: " + state);
+        var on = (state == "playing");
+        callback(null, on);
+      }
+    }.bind(this));
+  }
+  else {
+     this.device.getMuted(function(err, state) {
 
-    if (err) {
-      callback(err);
-    }
-    else {
-      this.log.warn("Current state for Sonos: " + state);
-      var on = (state == false);
-      callback(null, on);
-    }
+      if (err) {
+        callback(err);
+      }
+      else {
+        this.log.warn("Current state for Sonos: " + state);
+        var on = (state == false);
+        callback(null, on);
+      }
+    }.bind(this));
 
-  }.bind(this));
+  }
 }
 
 SonosAccessory.prototype.setOn = function(on, callback) {
@@ -246,29 +261,54 @@ SonosAccessory.prototype.setOn = function(on, callback) {
 
   this.log("Setting power to " + on);
   
-  if (on) {
-    this.device.setMuted(false, function(err, success) {
-      this.log("Unmute attempt with success: " + success);
-      if (err) {
-        callback(err);
-      }
-      else {
-        callback(null);
-      }
-    }.bind(this));
+  if (!this.mute){
+    if (on) {
+      this.device.play(function(err, success) {
+        this.log("Playback attempt with success: " + success);
+        if (err) {
+          callback(err);
+        }
+        else {
+          callback(null);
+        }
+      }.bind(this));
+    }
+    else {
+        this.device.stop(function(err, success) {
+            this.log("Stop attempt with success: " + success);
+            if (err) {
+              callback(err);
+            }
+            else {
+              callback(null);
+            }
+        }.bind(this));
+    }
   }
   else {
-      this.device.setMuted(true, function(err, success) {
-          this.log("Mute attempt with success: " + success);
-          if (err) {
-            callback(err);
-          }
-          else {
-            callback(null);
-          }
+    if (on) {
+      this.device.setMuted(false, function(err, success) {
+        this.log("Unmute attempt with success: " + success);
+        if (err) {
+          callback(err);
+        }
+        else {
+          callback(null);
+        }
       }.bind(this));
+    }
+    else {
+        this.device.setMuted(true, function(err, success) {
+            this.log("Mute attempt with success: " + success);
+            if (err) {
+              callback(err);
+            }
+            else {
+              callback(null);
+            }
+        }.bind(this));
+    }
   }
-
 }
 
 SonosAccessory.prototype.getVolume = function(callback) {


### PR DESCRIPTION
Play/Stop doesnt make sense on a Sonos Playbar, and this.device.play will return an error on the Playbar.

This change modifies the switch behavior to instead Mute/Unmute the speaker.
