### PR TITLE
Sonos 9.1 Update Fix + QoL Improvement.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var inherits = require('util').inherits;
 var Service, Characteristic, VolumeCharacteristic;
 var sonosDevices = new Map();
 var sonosAccessories = [];
-var Listener = require('../homebridge-sonos/node_modules/sonos/lib/events/listener');
+var Listener = require('sonos/lib/events/listener');
 
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;
@@ -157,7 +157,40 @@ function SonosAccessory(log, config) {
   this.search();
 }
 
+SonosAccessory.zoneTypeIsPlayable = function(zoneType) {
+  // 8 is the Sonos SUB, 4 is the Sonos Bridge, 11 is unknown
+  return zoneType != '11' && zoneType != '8' && zoneType != '4';
+}
+
 SonosAccessory.prototype.search = function() {
+  var search = sonos.search(function(device) {
+    var host = device.host;
+    this.log.debug("Found sonos device at %s", host);
+
+    device.deviceDescription(function (err, description) {
+
+        var zoneType = description["zoneType"];
+        var roomName = description["roomName"];
+
+        if (!SonosAccessory.zoneTypeIsPlayable(zoneType)) {
+          this.log.debug("Sonos device %s is not playable (has an unknown zone type of %s); ignoring", host, zoneType);
+          return;
+        }
+
+        if (roomName != this.room) {
+          this.log.debug("Ignoring device %s because the room name '%s' does not match the desired name '%s'.", host, roomName, this.room);
+          return;
+        }
+
+        this.log("Found a playable device at %s for room '%s'", host, roomName);
+        this.device = device;
+        search.destroy(); // we don't need to continue searching.
+
+    }.bind(this));
+  }.bind(this));
+}
+
+SonosAccessory.prototype.oldSearch = function() {
 
         sonosAccessories.push(this);
 

--- a/index.js
+++ b/index.js
@@ -257,8 +257,8 @@ SonosAccessory.prototype.setOn = function(on, callback) {
     }.bind(this));
   }
   else {
-      this.device.stop(function(err, success) {
-          this.log("Stop attempt with success: " + success);
+      this.device.pause(function(err, success) {
+          this.log("Pause attempt with success: " + success);
           if (err) {
             callback(err);
           }


### PR DESCRIPTION
Hey @nfarina!
So your fix for 9.1 works for finding the devices, but there was a little error: the search wasn't stopped properly and therefore a few seconds after discovery, the `sonos-node` plugin would time out and cause a crash.

Also bundled in here is a little QoL improvement, where we pause instead of stop the players. Been using it this way for a long time and think it's better since you can quickly pause and resume rather than starting a song over from the beginning. It's much better for podcasts too because it's not fun scrubbing through a 30min+ audio file, and having to go into the sonos app to do it!