### PR TITLE
Added support for multi-device rooms

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,9 +182,11 @@ SonosAccessory.prototype.search = function() {
           return;
         }
 
-        this.log("Found a playable device at %s for room '%s'", host, roomName);
-        this.device = device;
-        search.destroy(); // we don't need to continue searching.
+        if (null == this.device) { // avoin multiple call of search.destroy in multi-device rooms
+          this.log("Found a playable device at %s for room '%s'", host, roomName);
+          this.device = device;
+          search.destroy(); // we don't need to continue searching.
+        }
     }.bind(this));
   }.bind(this));
 }


### PR DESCRIPTION
I've got a room, where a Soundbar, a Sub and two Play:1 players a connected to one 'device'. As the same room name is assigned to all these devices, the search loop hits several times and crashes, as the search.destroy method is called multiple times. Fixed this.