### PR TITLE
Avoid crashes when search callback args are invaild

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,11 @@ SonosAccessory.prototype.search = function() {
     this.log.debug("Found sonos device at %s", host);
 
     device.deviceDescription(function (err, description) {
+    
+        if (description == undefined) {
+            this.log.debug('Ignoring callback because description is undefined (' + err + ')');
+            return;
+        }
 
         var zoneType = description["zoneType"];
         var roomName = description["roomName"];
@@ -182,7 +187,7 @@ SonosAccessory.prototype.search = function() {
           return;
         }
 
-        if (null == this.device) { // avoin multiple call of search.destroy in multi-device rooms
+        if (null == this.device) { // avoid multiple call of search.destroy in multi-device rooms
           this.log("Found a playable device at %s for room '%s'", host, roomName);
           this.device = device;
           search.destroy(); // we don't need to continue searching.


### PR DESCRIPTION
I experienced crashes of the plugin because 'device.deviceDescription(function (err, description)' was called with a 'null' description parameter. The 'err' object contained 'Error: socket hang up' in these cases. Of course the following access to 'var zoneType = description["zoneType"];' lead to a crash then.
Maybe the problem is local to me/my network, but...

Inserted a check against an 'undefined' 'description' argument.