### PR TITLE
Enable control of groups, information caching, add test environment for ease of development

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ The plugin is configured as part of your Homebridge `config.json` file.
       ]
     }
 
-The "mute" parameter is optional. Setting it to `true` will mute/unmute the speaker instead of a stop/play.
+The `name` parameter is how the device will apear in Apple Homekit.
 
 The `room` parameter must match the room name in Sonos *exactly*.
+
+The `mute` parameter is optional. Setting it to `true` will mute/unmute the speaker instead of a pause/play. (More information about how this parameter affects devices in groups can be found [below](#Device-Behavior-When-Grouped).)
 
 ## Example new config.json:
 
@@ -52,6 +54,21 @@ The `room` parameter must match the room name in Sonos *exactly*.
     	}]
     }
 
+## Advanced Configuration Values:
+
+These are additional (and optional) configuration parameters available, with their default values.
+
+          "groupCacheLifetime": 15,
+          "deviceCacheLifetime": 3600,
+
+`groupCacheLifetime` is the maximum amount of time (in seconds) the current Sonos group configuration will be cached in this plugin. The group configuration is how the devices on the current Sonos network are grouped (controlled via the Sonos app).
+
+Note: This setting is currently only used if `mute` is `false`. If `mute` is `true`, Sonos group information isn't used.
+
+`deviceCacheLifetime` is the maximum amount of time (in seconds) the information about each Sonos device discovered on the network will be cached.
+
+For the curious, an explanation of what these configurations do can be found [below](#Advanced-Configuration-explained).
+
 # Run Homebridge:
 
     $ homebridge
@@ -64,6 +81,24 @@ This is because Siri has many stronger associations for those words. For instanc
 
 You could of course pick any other unique name, like "Turn on the croissants" if you want. Or add it to a Scene with a custom phrase.
 
+## Device Behavior When Grouped
+
+### When `mute` is `false`
+The device status displayed in Homekit will reflect the status of the group the device is part of. On/off commands will result in the entire group being played or paused.
+
+### When `mute` is `true`
+The device status displayed in Homekit will reflect the status of the individual device. On/off commands will apply only to the individual device.
+
 # Alternative
 
 You also might check out this [fork of `homebridge-sonos`](https://github.com/dominicstelljes/homebridge-sonos) by [dominicstelljes](https://github.com/dominicstelljes) that exposes the Sonos as a "lightbulb" instead of a switch. This will allow you control the volume through Siri - "Set the Speakers to 50%" for example. But it will have some side-effects. Check out his README for more details.
+
+# Advanced Configuration explained:
+
+Additional network calls to Sonos devices are required to get detailed descriptions of each device and information about groups. If `mute` is `false` (using pause/play for control instead of mute/unmute), this information is used whenever Homekit requests status updates of devices and when requests to turn on/off (play/pause) are made from Homekit. Typically, Homekit will additionally request another status update for the device after a command is issued to play or pause the device.
+
+Requesting these details from Sonos devices every time simple actions are performed in Homekit are unnecessary, so the details retrieved from devices are cached to be used in the next lookup.
+
+Detailed device descriptions are unlikely to change often, so these can be cached for a longer period of time. The lifetime of this cache is controlled by `deviceCacheLifetime`, and is set to 1 hour by default. In most networks that are unlikely to change, this can practically be any large amount of time with no consequences.
+
+Groups, however, may change frequently or infrequently depending on the preferences of the user, and updates through the Sonos app will not be updated in this plugin until the group cache is refreshed. The lifetime of this cache is controlled by `groupCacheLifetime`. The default value of 15 seconds is long enough to ensure a single network call is enough to get the information for multiple uses instead of making the request every time, but (ideally) short enough to make the delay between group updates in Sonos app and the information being discovered in this plugin negligible.

--- a/config.schema.json
+++ b/config.schema.json
@@ -24,6 +24,20 @@
         "title": "Mute",
         "type": "boolean",
         "description": "This is optional. Checking this will mute/unmute the speaker instead of a stop/play."
+      },
+      "groupCacheLifetime": {
+        "title": "Group Cache Lifetime",
+        "type": "integer",
+        "default": 15,
+        "required": false,
+        "description": "Amount of time (in seconds) before refreshing the Sonos goup configuration."
+      },
+      "deviceCacheLifetime": {
+        "title": "Device Cache Lifetime",
+        "type": "integer",
+        "default": 3600,
+        "required": false,
+        "description": "Amount of time (in seconds) before refreshing detailed information about a given Sonos device on the network."
       }
     }
   },

--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ module.exports = function(homebridge) {
   Characteristic = homebridge.hap.Characteristic;
 
   homebridge.registerAccessory("homebridge-sonos", "Sonos", SonosAccessory);
+
+  // Not expected by Homebridge, but enables easy testing via test/init.js
+  return SonosAccessory;
 }
 
 //

--- a/index.js
+++ b/index.js
@@ -255,7 +255,13 @@ SonosAccessory.prototype.getServices = function() {
   return [this.service];
 }
 
-// device and description shared cache
+// Device and description cache.
+// Although this format should be 'static' and shared
+// across SonosAccessory instances, HomeBridge seems
+// to instantiate plugins in a way that keeps them entirely
+// separate, so this cache is distinct per instance.
+// However, the cache is still valuable to the individual
+// instance using it.
 SonosAccessory.deviceCache = {
   groups: {
     groups: null,
@@ -266,7 +272,7 @@ SonosAccessory.deviceCache = {
 
 SonosAccessory.prototype.getGroups = function() {
   if (Date.now() < SonosAccessory.deviceCache.groups.lastUpdate + (this.groupCacheLifetime)) {
-    // return cached group status if it was refreshed less than 15 seconds ago
+    // return cached group status if it was refreshed less than the configured lifetime ago
     return Promise.resolve(SonosAccessory.deviceCache.groups.groups);
   }
 
@@ -279,7 +285,7 @@ SonosAccessory.prototype.getGroups = function() {
 }
 
 SonosAccessory.prototype.getDeviceDescription = function(device) {
-  // use cached description if it's available and less than an hour old
+  // use cached description if it's available and refreshed less than the configured lifetime ago
   var cacheKey = `${device.host}:${device.port}`;
   var desc = SonosAccessory.deviceCache.descriptions[cacheKey];
   if (desc != undefined && desc.lastUpdate > Date.now() - this.deviceCacheLifetime) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
-    "sonos": "^0.12.1",
+    "sonos": "^1.7.0",
     "underscore": "^1.8.3"
   }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,115 @@
+# Simple Test Environment for Development
+
+init.js is a setup script for quick and easy testing of the plugin during development. The script sets up a test environment that mocks Homebridge, allowing development without the overhead of actually running homebridge. It then allows the control of real world Sonos devices through the plugin to test scenarios and validate functionality.
+
+Example usage:
+
+    $> node
+
+    > var sonos = require('./init.js');
+    Mock homebridge: registered plugin=homebridge-sonos, accessory=Sonos, constructor=SonosAccessory.
+    Mock homebridge: getting Characteristic.On.
+    Mock homebridge: adding action for event get.
+    Mock homebridge: adding action for event set.
+    Mock homebridge: adding for Characteristic.Volume.
+    Mock homebridge: adding action for event get.
+    Mock homebridge: adding action for event set.
+    DEBUG: Found sonos device at 192.168.1.1
+    DEBUG: Refreshing cached description for device 192.168.1.1:1400
+    Found a playable device at 192.168.1.1 for room 'Bedroom'
+
+    > sonos.getOn()
+    DEBUG: Refreshing group cache
+    WARN: Current state for Sonos: stopped
+    callback: result=false; error=null
+
+    > sonos.setOn(true)
+    Setting power to true
+    Playback attempt with success: true
+    callback: result=undefined; error=null
+
+    > sonos.getOn()
+    WARN: Current state for Sonos: playing
+    callback: result=true; error=null
+
+    > sonos.setOn(false)
+    Setting power to false
+    Pause attempt with success: true
+    callback: result=undefined; error=null
+
+# Requirements
+
+Although this test environment avoids the requirement of running homebridge, it does require actually having Sonos devices on the same network with the development machine. The test environment allows real control of Sonos devices through the plugin, so without any devices, there will be nothing to control.
+
+# Options
+
+## Configuration
+
+The initialization script contains a configuration object that is passed to the plugin so it can be configured for the specific Sonos setup of the developer. Values can be set to anything desired for testing purposes.
+
+    var config = {
+        "name": "Bedroom Speaker",
+        "room": "Bedroom",
+        "mute": false,
+        "groupCacheExpiration": 15,
+        "deviceCacheExpiration": 3600
+    };
+
+## Logging
+
+A logger is passed to the plugin so full logging works. Deeper logging levels (warn, error, debug) can be suppressed by setting that level to `false`.
+
+    var logLevelsEnabled = {
+        warn: true,
+        error: true,
+        debug: true
+    }
+
+## Mock Homebridge Initialization Messages
+
+A function defines the console output of plugin initialization with Homebridge (or the mock, in this case). If seeing these messages is not desired, just comment out the console.log() line.
+
+    function mockHomebridgeOutput(message, ...parameters) {
+        // Simple logging function to demonstrate plugin performing setup with Homebridge.
+        // Comment line below to suppress these messages.
+        console.log("Mock homebridge: " + message, ...parameters);
+    };
+
+# Testing Ideas
+
+## Direct Accessory Access and Shortcuts
+
+By default, the automatically-initialized accessory is exported to invoke directly, as well as simple shortcut functions into the accessory, just to reduce the amount of typing necessary when testing.
+
+    > sonos.sonos.getOn()
+
+is equivalent to
+
+    > sonos.getOn()
+
+## On-The-Fly Log Levels
+
+ The log level structure is exported to allow on-the-fly customization of what logs are printed while testing. This makes it possible to, for example, initialize the test environment with the bare-minimum logs output, then enable all the levels again to see what's going on in invocations of other features later.
+
+    > var sonos = require('./init.js');
+    Found a playable device at 192.168.1.1 for room 'Bedroom'
+
+    > sonos.logLevels.debug = sonos.logLevels.warn = true
+    true
+    
+    > sonos.getOn()
+    DEBUG: Refreshing group cache
+    WARN: Current state for Sonos: stopped
+    callback: result=false; error=null
+
+## Additional Accessories
+
+The logger is also exported, along with the SonosAccessory() constructor, to allow creating a second (and third, and...) instance of an accessory directly from the console.
+
+    > var config2 = { "name": "Kitchen Speaker", "room": "Kitchen" }
+    > var device2 = new sonos.SonosAccessory(sonos.log, config2)
+    Found a playable device at 192.168.1.2 for room 'Kitchen'
+    
+    > sonos.getOn()
+    WARN: Current state for Sonos: playing
+    callback: result=true; error=null

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,96 @@
+var HomebridgeSonos = require('../index.js');
+
+// Config to pass to instance of accessory created.
+// Modify to reflect your setup for testing.
+var config = {
+    "name": "Bedroom Speaker",
+    "room": "Bedroom",
+    "mute": false,
+    "groupCacheExpiration": 15,
+    "deviceCacheExpiration": 3600
+  };
+
+// Control what log levels are visible during testing
+var logLevelsEnabled = {
+    warn: true,
+    error: true,
+    debug: true
+};
+
+function mockHomebridgeOutput(message, ...parameters) {
+    // Simple logging function to demonstrate plugin performing setup with Homebridge.
+    // Comment line below to suppress these messages.
+    console.log("Mock homebridge: " + message, ...parameters);
+};
+
+// Mock logger to pass to plugin
+var log = (msg, ...parameters) => console.log(msg, ...parameters);
+log.info = log;
+log.warn = (msg, ...parameters) => { if (logLevelsEnabled.warn) console.log("WARN: " + msg, ...parameters); };
+log.error = (msg, ...parameters) => { if (logLevelsEnabled.error) console.log("ERROR: " + msg, ...parameters); };
+log.debug = (msg, ...parameters) => { if (logLevelsEnabled.debug) console.log("DEBUG: " + msg, ...parameters); };
+
+// Mock Homebridge - just a placeholder structure to satisfy requirements of SonosAccessory.
+// May need to be expanded in case further Homebridge functionality is used in plugin later.
+var homebridge = {
+    registerAccessory: (pluginName, accessoryName, accessoryPluginConstructor) =>
+        mockHomebridgeOutput(`registered plugin=${pluginName}, accessory=${accessoryName}, constructor=${accessoryPluginConstructor.name}.`),
+    hap: {
+        Service: {
+            Switch: function (name) {
+                var eventActions = {};
+                function onEvent(event, boundFunction) {
+                    mockHomebridgeOutput(`adding action for event ${event}.`);
+                    eventActions[event] = boundFunction;
+                    return {
+                        on: onEvent
+                    };
+                };
+                return {
+                    getCharacteristic: (characteristic) => {
+                        mockHomebridgeOutput(`getting Characteristic.${characteristic}.`);
+                        return {
+                            on: onEvent
+                        };
+                    },
+                    addCharacteristic: (characteristic) => {
+                        mockHomebridgeOutput(`adding for Characteristic.${characteristic}.`);
+                        return {
+                            on: onEvent
+                        };
+                    }
+                };
+            }
+        },
+        Characteristic: {
+            On: "On",
+            Volume: "Volume"
+        }
+    }
+};
+
+// Instantiate an instance of a plugin accessory
+var SonosAccessory = HomebridgeSonos(homebridge);
+var sonos = new SonosAccessory(log, config);
+
+// Simple callback to pass to plugin actions to observe what is happening
+function callback(err, r) { console.log(`callback: result=${r}; error=${err}`); };
+
+module.exports = {
+
+    // The instantiated plugin, to invoke directly
+    sonos: sonos,
+
+    // Exposing shorthands to plugin functionality
+    getOn: function() { sonos.getOn(callback); },
+    setOn: function(on) { sonos.setOn(on, callback); },
+
+    // Additional exports for playing around with in the console,
+    // with ability to dynamically update accessory behavior
+    log: log,
+    config: config,
+    logLevels: logLevelsEnabled,
+
+    // Export constructor directly so additional accessories can be created on-the-fly if desired
+    Sonos: SonosAccessory
+}


### PR DESCRIPTION
- When `mute` is set to `false`, use the group coordinator when getting and controlling play status.
  - The idea is to take the "logical" action - if a speaker in a group is to be paused, and it's in a group, the entire group should be paused (which is what would happen via the Sonos app). The status for the speaker should also reflect the coordinator, since the real-world "audible" status would be identical.  However, the current behavior results in no action (and incorrect status) if the accessory being controlled is not the coordinator.
  - The "logical" action isn't as obvious if the accessory is configured to mute, though, since muting an individual speaker would still work as expected, and may be the desired outcome.  I therefore left this as-is.
  - Note: I had to update the version of the sonos package to get the details of the group configuration.
- Cache device information (device description, group configuration) to reduce amount of network traffic.
  - This is especially helpful for scenarios when homekit issues an "on" or "off" command, where the status is likely checked before and again immediately after the command.
  - Homebridge seems to instantiate the plugin/accessories in a way that results in each accessory having its own cache for some reason.  It's not ideal, but still an improvement over no caching.
- Updated readme with new relevant details.
- During development, I created a script to initialize a test environment for testing.  I thought this might be valuable to others as well, so I've included it and written up some documentation for it.

Note: the diff for index.js looks larger than it really is: a lot of it is indentation updates to make it easier to read.  If you enable the "ignore whitespace" setting when reviewing, my updates will be clearer.